### PR TITLE
Use AND conjunction in /admin/content route permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.5] - 2023-07-10
+### Fixed
+- **BC** Use AND conjunction in Route Alter ([#22](https://github.com/wieni/wienimal_editor_toolbar/pull/22))
+    - Editors now require `access content overview` _and_ `access editor toolbar` to visit the `/admin/content` route
+
 ## [4.1.4] - 2022-03-26
 ### Added
 - Add support for the [Node Singles](https://www.drupal.org/project/node_singles) module

--- a/src/EventSubscriber/Routing/AdminContentRouteSubscriber.php
+++ b/src/EventSubscriber/Routing/AdminContentRouteSubscriber.php
@@ -18,7 +18,7 @@ class AdminContentRouteSubscriber extends RouteSubscriberBase
     protected function alterRoutes(RouteCollection $collection): void
     {
         if ($route = $collection->get('system.admin_content')) {
-            $permission = implode('+', array_filter([
+            $permission = implode(',', array_filter([
                 $route->getRequirement('_permission'),
                 'access editor toolbar',
             ]));


### PR DESCRIPTION
Currently you can access `/admin/content` if you have the `access editor toolbar` permission.
You don't need the original `access content overview` permission.

This is because we are using "+" OR conjunction in our Route alter.
We should use "," AND conjunction.

    # conjunction via OR uses + operator
    _permission: 'permission_a+permission_b'
    # conjunction via AND uses , operator
    _permission: 'permission_a,permission_b'

See https://www.drupal.org/node/2341759
