### PR TITLE
Add `HOOK_wienimal_editor_toolbar_manipulators_alter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.6] - 2023-07-10
+### Added
+- Add `HOOK_wienimal_editor_toolbar_manipulators_alter` hook ([#23](https://github.com/wieni/wienimal_editor_toolbar/pull/23))
+
 ## [4.1.5] - 2023-07-10
 ### Fixed
 - **BC** Use AND conjunction in Route Alter ([#22](https://github.com/wieni/wienimal_editor_toolbar/pull/22))

--- a/src/Service/EditorToolbarMenuBuilder.php
+++ b/src/Service/EditorToolbarMenuBuilder.php
@@ -95,6 +95,8 @@ class EditorToolbarMenuBuilder implements TrustedCallbackInterface
             $manipulators[] = ['callable' => 'toolbar_tools_menu_navigation_links'];
         }
 
+        $this->moduleHandler->alter('wienimal_editor_toolbar_manipulators', $manipulators, $menuName);
+
         $tree = $this->menuTree->transform($tree, $manipulators);
 
         // Finally, build a renderable array from the transformed tree.

--- a/wienimal_editor_toolbar.api.php
+++ b/wienimal_editor_toolbar.api.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Alter the menu tree manipulators used by the editor toolbar.
+ *
+ * @see \Drupal\wienimal_editor_toolbar\Service\EditorToolbarMenuBuilder::buildMenu()
+ * @param array $manipulators
+ * @param string $menuName
+ */
+function hook_wienimal_editor_toolbar_manipulators_alter(array &$manipulators, string $menuName): void
+{
+    $manipulators[] = [
+        'callable' => 'my_module.my_service:hideMenuItems',
+    ];
+}


### PR DESCRIPTION
This PR allows other modules to manipulate the toolbar menu.

I want to be able to dynamically (based on user attributes) modify certain menu items in the toolbar.

I would like to replace the `Content overview` menu link I have defined my `my_module.links.menu.editor.yml` with a link to `entity.taxonomy_vocabulary.collection` if the current user has it set as a preference.
The rest of the menu can remain the same.

<details>
<summary><code>config/sync/wienimal_editor_toolbar.settings.yml</code></summary>

```yaml
menu: editor
menu_items:
  expand: {  }
  remove:
    - 'admin_toolbar_tools.extra_links:media_page'
  unclickable:
    - wienimal_editor_toolbar.content_add
  version_info:
    enable: true
  content_overview:
    enable: true
    entity_types:
      node: true
      taxonomy_term: true
  content_add:
    enable: true
    entity_types:
      node: true
      taxonomy_term: true
langcode: nl
```

</details>

<details>
<summary><code>my_module/my_module.links.menu.editor.yml</code></summary>

```yaml
my_module.editor.content:
    title: 'Content'
    route_name: '<nolink>'
    weight: 1

my_module.editor.content.overview:
    title: 'Content overview'
    description: 'List all content of a specific type'
    route_name: system.admin_content
    parent: my_module.editor.content
    weight: 1

my_module.editor.content.overview.derivatives:
    parent: my_module.editor.content.overview
    deriver: Drupal\wienimal_editor_toolbar\Plugin\Derivative\ContentOverviewMenuItem
```

</details>

---

I'm certain there is a way to do this without having to fallback to adding a manipulator.
But I have other use-cases too that could be solved by adding a manipulator. So I'm making it easy on myself here..

- Hiding a certain menu item without denying access to the underlying route
- Changing the order for users with a specific role